### PR TITLE
Use more reliable way to check linger status

### DIFF
--- a/lib/tomo/plugin/sidekiq/tasks.rb
+++ b/lib/tomo/plugin/sidekiq/tasks.rb
@@ -37,8 +37,10 @@ module Tomo::Plugin::Sidekiq
     end
 
     def linger_must_be_enabled!
-      loginctl_result = remote.run "loginctl", "user-status", remote.host.user
-      return unless loginctl_result.stdout.match?(/^\s*Linger:\s*no\s*$/i)
+      linger_users = remote.list_files(
+        "/var/lib/systemd/linger", raise_on_error: false
+      )
+      return if dry_run? || linger_users.include?(remote.host.user)
 
       die <<~ERROR.strip
         Linger must be enabled for the #{remote.host.user} user in order for


### PR DESCRIPTION
Before Ubuntu 18, loginctl user-status would not indicate whether linger was enabled. As a result, it was easy to deploy an app via tomo and forget to turn linger on, sidekiq would fail to stay running, and this was hard to troubleshoot.

We can make this more reliable by checking the filesystem for linger status, since what loginctl enable-linger does under the hood is just create a file under /var/lib/systemd/linger/. Now sidekiq:setup_systemd will provide a helpful error message if linger is not enabled, even on older versions of Ubuntu.