### PR TITLE
Reorganize and update boilerplate to match latest tomo-plugin recommendations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-performance
+require:
+  - rubocop-minitest
+  - rubocop-performance
 
 AllCops:
   DisplayCopNames: true
@@ -30,7 +32,7 @@ Lint/StructNewOverride:
   Enabled: true
 
 Metrics/AbcSize:
-  Max: 16
+  Max: 20
   Exclude:
     - "test/**/*"
 
@@ -44,6 +46,7 @@ Metrics/ClassLength:
     - "test/**/*"
 
 Metrics/MethodLength:
+  Max: 18
   Exclude:
     - "test/**/*"
 
@@ -88,6 +91,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/NumericPredicate:
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a [tomo](https://github.com/mattbrictson/tomo) plugin that provides task
 - [Installation](#installation)
 - [Settings](#settings)
 - [Tasks](#tasks)
+- [Recommendations](#recommendations)
 - [Support](#support)
 - [License](#license)
 - [Code of conduct](#code-of-conduct)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/tomo-plugin-sidekiq.svg)](https://rubygems.org/gems/tomo-plugin-sidekiq)
 [![Travis](https://img.shields.io/travis/mattbrictson/tomo-plugin-sidekiq.svg?label=travis)](https://travis-ci.org/mattbrictson/tomo-plugin-sidekiq)
-[![Circle](https://circleci.com/gh/mattbrictson/tomo-plugin-sidekiq.svg?style=shield)](https://circleci.com/gh/mattbrictson/tomo-plugin-sidekiq)
+[![Circle](https://circleci.com/gh/mattbrictson/tomo-plugin-sidekiq.svg?style=shield)](https://app.circleci.com/pipelines/github/mattbrictson/tomo-plugin-sidekiq?branch=master)
 [![Code Climate](https://codeclimate.com/github/mattbrictson/tomo-plugin-sidekiq/badges/gpa.svg)](https://codeclimate.com/github/mattbrictson/tomo-plugin-sidekiq)
 
 This is a [tomo](https://github.com/mattbrictson/tomo) plugin that provides tasks for managing [sidekiq](https://github.com/mperham/sidekiq) via [systemd](https://en.wikipedia.org/wiki/Systemd), based on the recommendations in the sidekiq documentation. This plugin assumes that you are also using the tomo `rbenv` and `env` plugins, and that you are using a systemd-based Linux distribution like Ubuntu 18 LTS.

--- a/lib/tomo/plugin/sidekiq.rb
+++ b/lib/tomo/plugin/sidekiq.rb
@@ -2,18 +2,14 @@ require "tomo"
 require_relative "sidekiq/tasks"
 require_relative "sidekiq/version"
 
-module Tomo
-  module Plugin
-    module Sidekiq
-      extend Tomo::PluginDSL
+module Tomo::Plugin::Sidekiq
+  extend Tomo::PluginDSL
 
-      tasks Tomo::Plugin::Sidekiq::Tasks
+  tasks Tomo::Plugin::Sidekiq::Tasks
 
-      # rubocop:disable Layout/LineLength
-      defaults sidekiq_systemd_service: "sidekiq_%{application}.service",
-               sidekiq_systemd_service_path: ".config/systemd/user/%{sidekiq_systemd_service}",
-               sidekiq_systemd_service_template_path: File.expand_path("sidekiq/service.erb", __dir__)
-      # rubocop:enable Layout/LineLength
-    end
-  end
+  # rubocop:disable Layout/LineLength
+  defaults sidekiq_systemd_service: "sidekiq_%{application}.service",
+           sidekiq_systemd_service_path: ".config/systemd/user/%{sidekiq_systemd_service}",
+           sidekiq_systemd_service_template_path: File.expand_path("sidekiq/service.erb", __dir__)
+  # rubocop:enable Layout/LineLength
 end

--- a/lib/tomo/plugin/sidekiq/tasks.rb
+++ b/lib/tomo/plugin/sidekiq/tasks.rb
@@ -2,7 +2,6 @@ module Tomo::Plugin::Sidekiq
   class Tasks < Tomo::TaskLibrary
     SystemdUnit = Struct.new(:name, :template, :path)
 
-    # rubocop:disable Metrics/AbcSize
     def setup_systemd
       linger_must_be_enabled!
 
@@ -12,7 +11,6 @@ module Tomo::Plugin::Sidekiq
       remote.run "systemctl --user daemon-reload"
       remote.run "systemctl", "--user", "enable", service.name
     end
-    # rubocop:enable Metrics/AbcSize
 
     %i[reload restart start stop status].each do |action|
       define_method(action) do

--- a/lib/tomo/plugin/sidekiq/version.rb
+++ b/lib/tomo/plugin/sidekiq/version.rb
@@ -1,7 +1,8 @@
 module Tomo
   module Plugin
-    module Sidekiq
-      VERSION = "0.3.0".freeze
-    end
   end
+end
+
+module Tomo::Plugin::Sidekiq
+  VERSION = "0.3.0".freeze
 end

--- a/tomo-plugin-sidekiq.gemspec
+++ b/tomo-plugin-sidekiq.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters", "~> 1.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rubocop", "0.81.0"
+  spec.add_development_dependency "rubocop-minitest", "0.8.1"
   spec.add_development_dependency "rubocop-performance", "1.5.2"
 end


### PR DESCRIPTION
- Add rubocop-minitest
- Loosen up rubocop guidelines
- Point to new CircleCI pipelines UI
- Declare `Tomo::Plugin::Sidekiq` instead of using nested module syntax