### PR TITLE
Fix misconfiguration that prevented Sidekiq from starting automatically on boot

### DIFF
--- a/lib/tomo/plugin/sidekiq/service.erb
+++ b/lib/tomo/plugin/sidekiq/service.erb
@@ -19,4 +19,4 @@ WorkingDirectory=<%= paths.current %>
 Environment=MALLOC_ARENA_MAX=2
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
We install sidekiq as a user-level systemd service. For user-level services, `WantedBy=multi-user.target` does not work. That meant that sidekiq would not get started automatically on boot.

Fix by changing to `WantedBy=default.target`. Now sidekiq will start on boot.

To take advantage of this fix, re-run:

```
$ tomo run sidekiq:setup_systemd
```