### PR TITLE
Reformat Ruby files for line length of 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Layout/HashAlignment:
     - key
 
 Layout/LineLength:
+  Max: 120
   Exclude:
     - "*.gemspec"
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,12 +31,9 @@ namespace :bump do
     lowest_minor = RubyVersions.lowest_supported_minor
     latest = RubyVersions.latest
 
-    replace_in_file "tomo-plugin-sidekiq.gemspec",
-                    /ruby_version = ">= (.*)"/ => lowest
-
+    replace_in_file "tomo-plugin-sidekiq.gemspec", /ruby_version = ">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
-    replace_in_file ".circleci/config.yml",
-                    %r{circleci/ruby:([\d\.]+)} => latest
+    replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d\.]+)} => latest
 
     travis = YAML.safe_load(open(".travis.yml"))
     travis["rvm"] = RubyVersions.latest_supported_patches + ["ruby-head"]
@@ -87,9 +84,7 @@ module RubyVersions
 
     def versions
       @_versions ||= begin
-        yaml = URI.open(
-          "https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml"
-        )
+        yaml = URI.open("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml")
         YAML.safe_load(yaml, symbolize_names: true)
       end
     end

--- a/lib/tomo/plugin/sidekiq.rb
+++ b/lib/tomo/plugin/sidekiq.rb
@@ -6,10 +6,7 @@ module Tomo::Plugin::Sidekiq
   extend Tomo::PluginDSL
 
   tasks Tomo::Plugin::Sidekiq::Tasks
-
-  # rubocop:disable Layout/LineLength
   defaults sidekiq_systemd_service: "sidekiq_%{application}.service",
            sidekiq_systemd_service_path: ".config/systemd/user/%{sidekiq_systemd_service}",
            sidekiq_systemd_service_template_path: File.expand_path("sidekiq/service.erb", __dir__)
-  # rubocop:enable Layout/LineLength
 end

--- a/lib/tomo/plugin/sidekiq/tasks.rb
+++ b/lib/tomo/plugin/sidekiq/tasks.rb
@@ -19,9 +19,7 @@ module Tomo::Plugin::Sidekiq
     end
 
     def log
-      remote.attach "journalctl", "-q",
-                    raw("--user-unit=#{service.name.shellescape}"),
-                    *settings[:run_args]
+      remote.attach "journalctl", "-q", raw("--user-unit=#{service.name.shellescape}"), *settings[:run_args]
     end
 
     private
@@ -35,9 +33,7 @@ module Tomo::Plugin::Sidekiq
     end
 
     def linger_must_be_enabled!
-      linger_users = remote.list_files(
-        "/var/lib/systemd/linger", raise_on_error: false
-      )
+      linger_users = remote.list_files("/var/lib/systemd/linger", raise_on_error: false)
       return if dry_run? || linger_users.include?(remote.host.user)
 
       die <<~ERROR.strip


### PR DESCRIPTION
The rubocop community has decided to standardize on 120 characters for default line length.

https://github.com/rubocop-hq/rubocop/pull/7952

Update rubocop config and reformat ruby files to embrace this convention.