### PR TITLE
Adopt latest sidekiq recommendations for systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 This is a [tomo](https://github.com/mattbrictson/tomo) plugin that provides tasks for managing [sidekiq](https://github.com/mperham/sidekiq) via [systemd](https://en.wikipedia.org/wiki/Systemd), based on the recommendations in the sidekiq documentation. This plugin assumes that you are also using the tomo `rbenv` and `env` plugins, and that you are using a systemd-based Linux distribution like Ubuntu 18 LTS.
 
+**This plugin requires Sidekiq 6.0.6 or newer.**
+
 ---
 
 - [Installation](#installation)

--- a/lib/tomo/plugin/sidekiq/service.erb
+++ b/lib/tomo/plugin/sidekiq/service.erb
@@ -4,14 +4,14 @@ After=syslog.target network.target
 ConditionPathExists=<%= paths.current %>
 
 [Service]
-ExecReload=/usr/bin/kill -TSTP $MAINPID
 ExecStart=/bin/bash -lc 'exec bundle exec sidekiq'
-Restart=on-failure
+Restart=always
 RestartSec=1
 StandardError=syslog
 StandardOutput=syslog
 SyslogIdentifier=%n
-Type=simple
+Type=notify
+WatchdogSec=10
 WorkingDirectory=<%= paths.current %>
 
 # Greatly reduce Ruby memory fragmentation and heap usage


### PR DESCRIPTION
This PR updates the systemd configuration to match the latest recommendations from the official Sidekiq repo: https://github.com/mperham/sidekiq/blob/main/examples/systemd/sidekiq.service

Specifically, this changes the following:

- The configuration now uses `Type=notify` instead of `Type=simple`
- As a result, Sidekiq 6.0.6 or newer is now required
- `ExecReload` is removed, in favor of the standard `systemctl restart` behavior
- Use `Restart=always` as suggested by https://github.com/mperham/sidekiq/pull/5259

Marking this as a potentially "breaking" change due to the new minimum version requirement for Sidekiq.