### PR TITLE
Replace minitest-reporters with minitest-rg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.11"
-gem "minitest-reporters", "~> 1.3"
+gem "minitest-rg", "~> 5.3"
 gem "rake", "~> 13.0"
 gem "rubocop", "1.58.0"
 gem "rubocop-minitest", "0.33.0"

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,2 +1,0 @@
-require "minitest/reporters"
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new, ENV, Minitest.backtrace_filter)

--- a/test/support/rg.rb
+++ b/test/support/rg.rb
@@ -1,0 +1,2 @@
+# Enable color test output
+require "minitest/rg"


### PR DESCRIPTION
Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins