### PR TITLE
Resolve syslog obsolete warnings

### DIFF
--- a/lib/tomo/plugin/sidekiq/service.erb
+++ b/lib/tomo/plugin/sidekiq/service.erb
@@ -7,8 +7,6 @@ ConditionPathExists=<%= paths.current %>
 ExecStart=/bin/bash -lc 'exec bundle exec sidekiq'
 Restart=always
 RestartSec=1
-StandardError=syslog
-StandardOutput=syslog
 SyslogIdentifier=%n
 Type=notify
 WatchdogSec=10


### PR DESCRIPTION
Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.